### PR TITLE
Fix numerical coercion of clinical columns

### DIFF
--- a/nccid_cleaning/cleaning.py
+++ b/nccid_cleaning/cleaning.py
@@ -152,6 +152,7 @@ def _coerce_numeric_columns(patients_df: pd.DataFrame) -> pd.DataFrame:
                 return float(match_error.group("systolic"))
             elif match_error and kind == "diastolic":
                 return float(match_error.group("diastolic"))
+        return np.nan
 
     # standard clinical columns to be cleaned
     clinical_columns = (

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,4 +1,5 @@
 # content of test_sysexit.py
+import numpy as np
 import pandas as pd
 
 import nccid_cleaning as nc
@@ -31,3 +32,18 @@ def test_example():
 
     # Test the equivalence
     pd.testing.assert_frame_equal(df_cleaned, df_target)
+
+
+def test_coerce_numeric_columns_when_no_values():
+    val = ""
+    cols = (
+        "Fibrinogen  if d-dimer not performed",
+        "Urea on admission",
+        "O2 saturation",
+        "Temperature on admission",
+    )
+
+    df = pd.DataFrame([[val for _ in range(len(cols))]], columns=cols)
+    df = nc.cleaning._coerce_numeric_columns(df)
+    output_cols = [col for col in df.columns if col not in cols]
+    assert (df[output_cols].dtypes == 'float64').all()


### PR DESCRIPTION
Hello and many thanks for providing the ingestion and cleaning utilities for NCCID!

This PR ensures that the [clinical columns](https://github.com/nhsx/nccid-cleaning/blob/master/nccid_cleaning/cleaning.py#L157-L177) get mapped to a numerical data type, via [_extract_clinical_values](https://github.com/nhsx/nccid-cleaning/blob/master/nccid_cleaning/cleaning.py#L133-L154), when any one of these columns does not contain data to extract, e.g. when the submitted data contains only whitespace `" "`. 

In the original case, an entire column of empty strings ends up being mapped to `None` which then leads to the following error in the cleaning pipeline:

```
nccid-cleaning/nccid_cleaning/cleaning.py", line 221, in <lambda>
    lambda x: x if 0 <= x <= 100 else np.nan
TypeError: '<=' not supported between instances of 'int' and 'NoneType'
```
This would not have been picked up when parsing a real and complete dataset.

Cheers